### PR TITLE
Actually apply patches

### DIFF
--- a/patches.go
+++ b/patches.go
@@ -62,7 +62,7 @@ func filterPatch(p v1beta1.Patch, only ...v1beta1.PatchType) bool {
 	}
 
 	for _, patchType := range only {
-		if patchType == p.Type {
+		if patchType == p.GetType() {
 			return false
 		}
 	}

--- a/render.go
+++ b/render.go
@@ -61,7 +61,7 @@ func RenderFromJSON(o resource.Object, data []byte) error {
 func RenderFromCompositePatches(cd resource.Composed, xr resource.Composite, p []v1beta1.Patch) error {
 	for i := range p {
 		if err := Apply(p[i], xr, cd, v1beta1.PatchTypeFromCompositeFieldPath, v1beta1.PatchTypeCombineFromComposite); err != nil {
-			return errors.Wrapf(err, errFmtPatch, p[i].Type, i)
+			return errors.Wrapf(err, errFmtPatch, p[i].GetType(), i)
 		}
 	}
 	return nil
@@ -72,7 +72,7 @@ func RenderFromCompositePatches(cd resource.Composed, xr resource.Composite, p [
 func RenderToCompositePatches(xr resource.Composite, cd resource.Composed, p []v1beta1.Patch) error {
 	for i := range p {
 		if err := Apply(p[i], xr, cd, v1beta1.PatchTypeToCompositeFieldPath, v1beta1.PatchTypeCombineToComposite); err != nil {
-			return errors.Wrapf(err, errFmtPatch, p[i].Type, i)
+			return errors.Wrapf(err, errFmtPatch, p[i].GetType(), i)
 		}
 	}
 	return nil


### PR DESCRIPTION
I ran some tests with https://marketplace.upbound.io/configurations/upbound/configuration-caas/v0.2.0/xrds and found that implicit `FromCompositeFieldPath` patches weren't being applied. This PR addresses that. It also adds some cursory logging.

```yaml
$ xrender claim.yaml composition.yaml functions.yaml
---
apiVersion: aws.caas.upbound.io/v1alpha1
kind: Cluster
metadata:
  name: aws-spoke-01
---
apiVersion: aws.caas.upbound.io/v1alpha1
kind: XServices
metadata:
  annotations:
    crossplane.io/composition-resource-name: composite-cluster-services
  generateName: aws-spoke-01-
  labels:
    crossplane.io/composite: aws-spoke-01
  ownerReferences:
  - apiVersion: aws.caas.upbound.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Cluster
    name: aws-spoke-01
    uid: ""
spec:
  gitops:
    url: https://github.com/upbound/caas-cluster-configuration
  providerConfigRef:
    name: aws-spoke-01
---
apiVersion: aws.caas.upbound.io/v1alpha1
kind: XNetwork
metadata:
  annotations:
    crossplane.io/composition-resource-name: composite-network-eks
  generateName: aws-spoke-01-
  labels:
    crossplane.io/composite: aws-spoke-01
  ownerReferences:
  - apiVersion: aws.caas.upbound.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Cluster
    name: aws-spoke-01
    uid: ""
spec:
  parameters:
    id: aws-spoke-01
    region: eu-central-1
```