### PR TITLE
Require string and math transform types

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ a lot more explicit and less ambiguous.
 * `resources[i].name` is now a required field.
 * `resources[i].connectionDetails[i].name` is now a required field
 * `resources[i].connectionDetails[i].type` is now a required field
+* `resources[i].patches[i].transforms[i].string.type` is now a required field
+* `resources[i].patches[i].transforms[i].math.type` is now a required field
 * `resources[i].patches[i].policy.mergeOptions` is no longer supported
 
 Functions use Kubernetes server-side apply, not `mergeOptions`, to intelligently

--- a/fn_test.go
+++ b/fn_test.go
@@ -166,6 +166,7 @@ func TestRunFunction(t *testing.T) {
 											{
 												Type: v1beta1.TransformTypeMath,
 												Math: &v1beta1.MathTransform{
+													Type:     v1beta1.MathTransformTypeMultiply,
 													Multiply: pointer.Int64(3),
 												},
 											},
@@ -229,6 +230,7 @@ func TestRunFunction(t *testing.T) {
 											{
 												Type: v1beta1.TransformTypeMath,
 												Math: &v1beta1.MathTransform{
+													Type:     v1beta1.MathTransformTypeMultiply,
 													Multiply: pointer.Int64(3),
 												},
 											},
@@ -574,6 +576,7 @@ func TestRunFunction(t *testing.T) {
 											{
 												Type: v1beta1.TransformTypeMath,
 												Math: &v1beta1.MathTransform{
+													Type:     v1beta1.MathTransformTypeMultiply,
 													Multiply: pointer.Int64(3),
 												},
 											},

--- a/input/v1beta1/resources_transforms.go
+++ b/input/v1beta1/resources_transforms.go
@@ -110,14 +110,6 @@ type MathTransform struct {
 	ClampMax *int64 `json:"clampMax,omitempty"`
 }
 
-// GetType returns the type of the math transform, returning the default if not specified.
-func (m *MathTransform) GetType() MathTransformType {
-	if m.Type == "" {
-		return MathTransformTypeMultiply
-	}
-	return m.Type
-}
-
 // MapTransform returns a value for the input from the given map.
 type MapTransform struct {
 	// Pairs is the map that will be used for transform.

--- a/patches_test.go
+++ b/patches_test.go
@@ -1079,6 +1079,7 @@ func TestResolveTransforms(t *testing.T) {
 				}, {
 					Type: v1beta1.TransformTypeMath,
 					Math: &v1beta1.MathTransform{
+						Type:     v1beta1.MathTransformTypeMultiply,
 						Multiply: pointer.Int64(2),
 					},
 				}},
@@ -1099,6 +1100,7 @@ func TestResolveTransforms(t *testing.T) {
 				}, {
 					Type: v1beta1.TransformTypeMath,
 					Math: &v1beta1.MathTransform{
+						Type:     v1beta1.MathTransformTypeMultiply,
 						Multiply: pointer.Int64(2),
 					},
 				}},

--- a/transforms.go
+++ b/transforms.go
@@ -108,7 +108,7 @@ func ResolveMath(t *v1beta1.MathTransform, input any) (any, error) {
 	default:
 		return nil, errors.Errorf(errFmtMathInputNonNumber, input)
 	}
-	switch t.GetType() {
+	switch t.Type {
 	case v1beta1.MathTransformTypeMultiply:
 		return resolveMathMultiply(t, input)
 	case v1beta1.MathTransformTypeClampMin, v1beta1.MathTransformTypeClampMax:
@@ -150,7 +150,7 @@ func resolveMathClamp(t *v1beta1.MathTransform, input any) (any, error) {
 		// should never happen as we validate the input type in ResolveMath
 		return nil, errors.Errorf(errFmtMathInputNonNumber, input)
 	}
-	switch t.GetType() { //nolint:exhaustive // We validate the type in ResolveMath
+	switch t.Type { //nolint:exhaustive // We validate the type in ResolveMath
 	case v1beta1.MathTransformTypeClampMin:
 		if in < *t.ClampMin {
 			return *t.ClampMin, nil

--- a/validate.go
+++ b/validate.go
@@ -204,7 +204,10 @@ func ValidateTransform(t v1beta1.Transform) *field.Error { //nolint:gocyclo // T
 
 // ValidateMathTransform validates a MathTransform.
 func ValidateMathTransform(m *v1beta1.MathTransform) *field.Error {
-	switch m.GetType() {
+	if m.Type == "" {
+		return field.Required(field.NewPath("type"), "math transform type is required")
+	}
+	switch m.Type {
 	case v1beta1.MathTransformTypeMultiply:
 		if m.Multiply == nil {
 			return field.Required(field.NewPath("multiply"), "must specify a value if a multiply math transform is specified")
@@ -266,8 +269,11 @@ func ValidateMatchTransformPattern(p v1beta1.MatchTransformPattern) *field.Error
 
 // ValidateStringTransform validates a StringTransform.
 func ValidateStringTransform(s *v1beta1.StringTransform) *field.Error { //nolint:gocyclo // just a switch
+	if s.Type == "" {
+		return field.Required(field.NewPath("type"), "string transform type is required")
+	}
 	switch s.Type {
-	case v1beta1.StringTransformTypeFormat, "":
+	case v1beta1.StringTransformTypeFormat:
 		if s.Format == nil {
 			return field.Required(field.NewPath("fmt"), "format transform requires a format")
 		}
@@ -309,7 +315,7 @@ func ValidateConvertTransform(t *v1beta1.ConvertTransform) *field.Error {
 // ValidateConnectionDetail checks if the connection detail is logically valid.
 func ValidateConnectionDetail(cd v1beta1.ConnectionDetail) *field.Error {
 	if cd.Type == "" {
-		return field.Required(field.NewPath("type"), "type is required")
+		return field.Required(field.NewPath("type"), "connection detail type is required")
 	}
 	if !cd.Type.IsValid() {
 		return field.Invalid(field.NewPath("type"), string(cd.Type), "unknown connection detail type")

--- a/validate_test.go
+++ b/validate_test.go
@@ -395,17 +395,6 @@ func TestValidateTransform(t *testing.T) {
 				},
 			},
 		},
-		"ValidMathDefaultType": {
-			reason: "Math transform with MathTransform Default set should be valid",
-			args: args{
-				transform: v1beta1.Transform{
-					Type: v1beta1.TransformTypeMath,
-					Math: &v1beta1.MathTransform{
-						Multiply: pointer.Int64(2),
-					},
-				},
-			},
-		},
 		"ValidMathClampMin": {
 			reason: "Math transform with valid MathTransform ClampMin set should be valid",
 			args: args{
@@ -602,6 +591,7 @@ func TestValidateTransform(t *testing.T) {
 				transform: v1beta1.Transform{
 					Type: v1beta1.TransformTypeString,
 					String: &v1beta1.StringTransform{
+						Type:   v1beta1.StringTransformTypeFormat,
 						Format: pointer.String("foo"),
 					},
 				},


### PR DESCRIPTION
This makes these fields effectively required. Previously they had defaults, but our Input isn't a real CRD with API server validation, so we don't enjoy that anymore.

Fixes https://github.com/crossplane-contrib/function-patch-and-transform/issues/15