### PR TITLE
WIP: Use crossplane CLI to build a package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 
 # Go workspace file
 go.work
+
+# Crossplane packaging things
+package/*.xpkg
+package/*.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,25 +10,11 @@ COPY *.go ./
 
 RUN CGO_ENABLED=0 go build -o /function .
 
-FROM debian:12.1-slim as package-stage
-
-# TODO(negz): Use a proper Crossplane package building tool. We're abusing the
-# fact that this image won't have an io.crossplane.pkg: base annotation. This
-# means Crossplane package manager will pull this entire ~100MB image, which
-# also happens to contain a valid Function runtime.
-# https://github.com/crossplane/crossplane/blob/v1.13.2/contributing/specifications/xpkg.md
-WORKDIR /package
-COPY package/ ./
-
-RUN cat crossplane.yaml > /package.yaml
-RUN cat input/*.yaml >> /package.yaml
-
 FROM gcr.io/distroless/base-debian11 AS build-release-stage
 
 WORKDIR /
 
 COPY --from=build-stage /function /function
-COPY --from=package-stage /package.yaml /package.yaml
 
 EXPOSE 9443
 

--- a/README.md
+++ b/README.md
@@ -239,8 +239,14 @@ ok      github.com/crossplane-contrib/function-patch-and-transform    0.021s  co
 # Lint the code
 $ docker run --rm -v $(pwd):/app -v ~/.cache/golangci-lint/v1.54.2:/root/.cache -w /app golangci/golangci-lint:v1.54.2 golangci-lint run
 
-# Build a Docker image - see Dockerfile
-$ docker build .
+# Build the Function runtime image
+$ docker image save $(docker build -q .) > package/runtime.tar
+
+# Build the Function package
+$ crossplane xpkg build -f package --controller-tar=package/runtime.tar
+
+# Push the Function package
+$ crossplane xpkg push -f package/*.xpkg xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 [Crossplane]: https://crossplane.io


### PR DESCRIPTION
This is my attempt at using the `crossplane` CLI to build this package. We want to do this because it will build an OCI image with [xpkg annotations](https://github.com/crossplane/crossplane/blob/e0adb7510ae0844d8c472d22aa8a8525978e4e92/contributing/specifications/xpkg.md) that allow the package manager to pull (and cache) only the package manifest, not the whole image.

I think there are a few improvements we should consider to this experience:

* `--controller` doesn't make sense for a Function. Elsewhere we're using `--runtime` as a generic alternative.
* I don't think it's possible to `xpkg push` to xpkg.upbound.io right now because we can't authenticate.
* In the happy path it would be amazing to just run `crossplane xpkg build` without first running `docker build`

I think (modulo naming) it's good to support the `--controller` and `--controller-tar` arguments for power users, but it would be neat if we could do some magic for the happy/simple path. Perhaps if you run `crossplane xpkg build` in a directory that has a `Dockerfile` we assume the `Dockerfile` builds your runtime image, and build it for you?