### PR TITLE
change list toType to array

### DIFF
--- a/input/v1beta1/resources_transforms.go
+++ b/input/v1beta1/resources_transforms.go
@@ -318,7 +318,7 @@ func (c ConvertTransformFormat) IsValid() bool {
 // A ConvertTransform converts the input into a new object whose type is supplied.
 type ConvertTransform struct {
 	// ToType is the type of the output of this transform.
-	// +kubebuilder:validation:Enum=string;int;int64;bool;float64;object;list
+	// +kubebuilder:validation:Enum=string;int;int64;bool;float64;object;array
 	ToType TransformIOType `json:"toType"`
 
 	// The expected input format.

--- a/package/input/pt.fn.crossplane.io_resources.yaml
+++ b/package/input/pt.fn.crossplane.io_resources.yaml
@@ -27,7 +27,9 @@ spec:
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           environment:
-            description: Environment represents the Composition environment.
+            description: "Environment represents the Composition environment. \n THIS
+              IS AN ALPHA FIELD. Do not use it in production. It may be changed or
+              removed without notice."
             properties:
               patches:
                 description: Patches is a list of environment patches that are executed
@@ -147,7 +149,7 @@ spec:
                                 - bool
                                 - float64
                                 - object
-                                - list
+                                - array
                                 type: string
                             required:
                             - toType
@@ -462,7 +464,7 @@ spec:
                                   - bool
                                   - float64
                                   - object
-                                  - list
+                                  - array
                                   type: string
                               required:
                               - toType
@@ -832,7 +834,7 @@ spec:
                                   - bool
                                   - float64
                                   - object
-                                  - list
+                                  - array
                                   type: string
                               required:
                               - toType


### PR DESCRIPTION
Brings in the fix from <https://github.com/crossplane/crossplane/pull/4825>

Updates the toType enum validation to include array instead of list. the docs PR https://github.com/crossplane/docs/pull/541 already captures it as array.

Fixes #21 