### PR TITLE
Don't build an amd64 binary in the arm64 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,13 +95,13 @@ jobs:
           target: image
           build-args:
             GO_VERSION=${{ env.GO_VERSION }}
-          outputs: type=docker,dest=runtime.tar
+          outputs: type=docker,dest=runtime-${{ matrix.arch }}.tar
       
       - name: Setup the Crossplane CLI
         run: "curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"
 
       - name: Build Package
-        run: ./crossplane xpkg build --package-file=${{ matrix.arch }}.xpkg --package-root=package/ --embed-runtime-image-tarball=runtime.tar
+        run: ./crossplane xpkg build --package-file=${{ matrix.arch }}.xpkg --package-root=package/ --embed-runtime-image-tarball=runtime-${{ matrix.arch }}.tar
       
       - name: Upload Single-Platform Package
         uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 
 # We use the latest Go 1.x version unless asked to use something else.
 ARG GO_VERSION=1
-ARG TARGETOS
-ARG TARGETARCH
 
 # Setup the base environment.
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS base
@@ -16,6 +14,8 @@ RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Build the Function.
 FROM base AS build
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \


### PR DESCRIPTION
Not entirely sure what's going on, but /function is definitely compiled for amd64 inside an image that is otherwise arm64.