### PR TITLE
add simple guidance for including results from previous functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,14 @@ With this function you can use P&T with other functions. For example you can
 create a desired resource using the [Go Templating][fn-go-templating] function,
 then patch the result using this function.
 
+To include results from previous functions, simply provide a `resources` entry
+for each and specify a `name` field that matches the name of the resource from
+the previous function. Also, do not specify any value for the `base` field of
+each resource.
+
 It's not just patches either. You can use P&T to derive composite resource
 connection details from a resource produced by another function, or use it to
-determine whether a resource produced by another function is ready
+determine whether a resource produced by another function is ready.
 
 ### Decouple P&T development from Crossplane core
 


### PR DESCRIPTION
I've seen the question asked a couple times now for "how do I patch resources using this function that were generated from a previous function in the pipeline?"

This PR tries to distill the guidance on how to accomplish this into a very streamlined entry in the README.

@phisco provided this guidance originally in https://crossplane.slack.com/archives/C031Y29CSAE/p1701706603079049?thread_ts=1701689312.869629&cid=C031Y29CSAE