### PR TITLE
Fix for v4 of the upload and download artifacts actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Upload Single-Platform Package
         uses: actions/upload-artifact@v4
         with:
-          name: packages
+          name: package-${{ matrix.arch }}
           path: "*.xpkg"
           if-no-files-found: error
           retention-days: 1
@@ -137,8 +137,8 @@ jobs:
       - name: Download Single-Platform Packages
         uses: actions/download-artifact@v4
         with:
-          name: packages
           path: .
+          merge-multiple: true
 
       - name: Setup the Crossplane CLI
         run: "curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"


### PR DESCRIPTION
These actions require artifact names to be unique across runs. We achieve this by uploading unique names, then downloading all of them.

See also https://github.com/crossplane/function-template-go/pull/53.