### PR TITLE
refactor: Move logic into `pkg/` to be imported elsewhere

### DIFF
--- a/internal/fn/connection.go
+++ b/internal/fn/connection.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/fn/connection_test.go
+++ b/internal/fn/connection_test.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"testing"

--- a/internal/fn/doc.go
+++ b/internal/fn/doc.go
@@ -1,0 +1,2 @@
+// Package fn contains internal function implementation.
+package fn

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"context"
@@ -27,6 +27,23 @@ type Function struct {
 	fnv1beta1.UnimplementedFunctionRunnerServiceServer
 
 	log logging.Logger
+}
+
+// FunctionOpt can modify a Function upon creation.
+type FunctionOpt func(f *Function)
+
+// WithLogger adds a logger to a Function.
+func WithLogger(log logging.Logger) FunctionOpt {
+	return func(f *Function) { f.log = log }
+}
+
+// NewFunction creates a new Function with the given options.
+func NewFunction(opts ...FunctionOpt) *Function {
+	f := &Function{}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
 }
 
 // RunFunction runs the Function.

--- a/internal/fn/fn_test.go
+++ b/internal/fn/fn_test.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"context"

--- a/internal/fn/patches.go
+++ b/internal/fn/patches.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"fmt"

--- a/internal/fn/patches_test.go
+++ b/internal/fn/patches_test.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"encoding/json"

--- a/internal/fn/ready.go
+++ b/internal/fn/ready.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"context"

--- a/internal/fn/ready_test.go
+++ b/internal/fn/ready_test.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"context"

--- a/internal/fn/transforms.go
+++ b/internal/fn/transforms.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"crypto/sha1" //nolint:gosec // Not used for secure hashing

--- a/internal/fn/transforms_test.go
+++ b/internal/fn/transforms_test.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"encoding/json"

--- a/internal/fn/validate.go
+++ b/internal/fn/validate.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"fmt"

--- a/internal/fn/validate_test.go
+++ b/internal/fn/validate_test.go
@@ -1,4 +1,4 @@
-package main
+package fn
 
 import (
 	"testing"

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/crossplane/function-sdk-go"
+
+	"github.com/crossplane-contrib/function-patch-and-transform/pkg/fn"
 )
 
 // CLI of this Function.
@@ -24,7 +26,10 @@ func (c *CLI) Run() error {
 		return err
 	}
 
-	return function.Serve(&Function{log: log},
+	return function.Serve(
+		fn.NewFunction(
+			fn.WithLogger(log),
+		),
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
 		function.Insecure(c.Insecure))

--- a/pkg/fn/fn.go
+++ b/pkg/fn/fn.go
@@ -1,0 +1,14 @@
+// Package fn defines the public interface for patch-and-transform functions.
+package fn
+
+import (
+	fninternal "github.com/crossplane-contrib/function-patch-and-transform/internal/fn"
+)
+
+var (
+	// NewFunction creates a new Function with the given options.
+	NewFunction = fninternal.NewFunction
+
+	// WithLogger adds a logger to a Function.
+	WithLogger = fninternal.WithLogger
+)


### PR DESCRIPTION
Fixes https://github.com/crossplane-contrib/function-patch-and-transform/issues/52

To reuse parts of the logic in this function elsewhere in another project the go files need to moved from the `main` package into another package since Go does not allow imports of `main` packages ("programs").

This moves all function logic into `pkg/fn/` and the `main.go` into `cmd/fn/`.

It also adds a `NewFunction` constructor with `WithLogger` option to circumvent the fact that `log` is a private field of `Function` (which is a bit cleaner and more function-al, anyways).