### PR TITLE
Always use p.GetType(), not p.Type

### DIFF
--- a/patches.go
+++ b/patches.go
@@ -246,7 +246,7 @@ func ComposedTemplates(pss []v1beta1.PatchSet, cts []v1beta1.ComposedTemplate) (
 	pn := make(map[string][]v1beta1.ComposedPatch)
 	for _, s := range pss {
 		for _, p := range s.Patches {
-			if p.Type == v1beta1.PatchTypePatchSet {
+			if p.GetType() == v1beta1.PatchTypePatchSet {
 				return nil, errors.New(errPatchSetType)
 			}
 		}
@@ -257,12 +257,12 @@ func ComposedTemplates(pss []v1beta1.PatchSet, cts []v1beta1.ComposedTemplate) (
 	for i, r := range cts {
 		var po []v1beta1.ComposedPatch
 		for _, p := range r.Patches {
-			if p.Type != v1beta1.PatchTypePatchSet {
+			if p.GetType() != v1beta1.PatchTypePatchSet {
 				po = append(po, p)
 				continue
 			}
 			if p.PatchSetName == nil {
-				return nil, errors.Errorf(errFmtRequiredField, "PatchSetName", p.Type)
+				return nil, errors.Errorf(errFmtRequiredField, "PatchSetName", p.GetType())
 			}
 			ps, ok := pn[*p.PatchSetName]
 			if !ok {

--- a/render.go
+++ b/render.go
@@ -65,14 +65,14 @@ func RenderFromJSON(o resource.Object, data []byte) error {
 func RenderEnvironmentPatches(env *unstructured.Unstructured, oxr, dxr *composite.Unstructured, ps []v1beta1.EnvironmentPatch) error {
 	for i, p := range ps {
 		p := p
-		switch p.Type {
+		switch p.GetType() {
 		case v1beta1.PatchTypeToEnvironmentFieldPath, v1beta1.PatchTypeCombineToEnvironment:
 			if err := ApplyToObjects(&p, env, oxr); err != nil {
-				return errors.Wrapf(err, errFmtPatch, p.Type, i)
+				return errors.Wrapf(err, errFmtPatch, p.GetType(), i)
 			}
 		case v1beta1.PatchTypeFromEnvironmentFieldPath, v1beta1.PatchTypeCombineFromEnvironment:
 			if err := ApplyToObjects(&p, env, dxr); err != nil {
-				return errors.Wrapf(err, errFmtPatch, p.Type, i)
+				return errors.Wrapf(err, errFmtPatch, p.GetType(), i)
 			}
 		case v1beta1.PatchTypePatchSet, v1beta1.PatchTypeFromCompositeFieldPath, v1beta1.PatchTypeCombineFromComposite, v1beta1.PatchTypeToCompositeFieldPath, v1beta1.PatchTypeCombineToComposite:
 			// nothing to do
@@ -95,7 +95,7 @@ func RenderComposedPatches( //nolint:gocyclo // just a switch
 ) (errs []error, store bool) {
 	for i, p := range ps {
 		p := p
-		switch t := p.Type; t {
+		switch t := p.GetType(); t {
 		case v1beta1.PatchTypeToCompositeFieldPath, v1beta1.PatchTypeCombineToComposite:
 			// TODO(negz): Should failures to patch the XR be terminal? It could
 			// indicate a required patch failed. A required patch means roughly

--- a/validate.go
+++ b/validate.go
@@ -104,7 +104,7 @@ func ValidateEnvironment(e *v1beta1.Environment) *field.Error {
 			v1beta1.PatchTypeFromEnvironmentFieldPath,
 			v1beta1.PatchTypeToEnvironmentFieldPath:
 		default:
-			return field.Invalid(field.NewPath("patches").Index(i).Key("type"), p.Type, "invalid environment patch type")
+			return field.Invalid(field.NewPath("patches").Index(i).Key("type"), p.GetType(), "invalid environment patch type")
 		}
 
 		if err := ValidatePatch(&p); err != nil {


### PR DESCRIPTION
Fixes https://github.com/crossplane-contrib/function-patch-and-transform/issues/74

GetType returns a default value if p.Type is empty. In upstream c/c CRD defaulting does this for us, but we can't rely on that here since our input is not a 'real' API object.