### PR TITLE
fix: allow using function only to patch to and from the environment

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -115,6 +115,14 @@ func (f *Function) RunFunction(ctx context.Context, req *fnv1beta1.RunFunctionRe
 		log.Debug("Loaded Composition environment from Function context", "context-key", fncontext.KeyEnvironment)
 	}
 
+	// Patching code assumes that the environment has a GVK, as it uses
+	// runtime.DefaultUnstructuredConverter.FromUnstructured. This is a bit odd,
+	// but it's what we've done in the past. We'll set a default GVK here if one
+	// isn't set.
+	if env.GroupVersionKind().Empty() {
+		env.SetGroupVersionKind(internalEnvironmentGVK)
+	}
+
 	if input.Environment != nil {
 		// Run all patches that are from the (observed) XR to the environment or
 		// from the environment to the (desired) XR.

--- a/fn_test.go
+++ b/fn_test.go
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -95,7 +94,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 				},
 			},
 		},
@@ -126,7 +125,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 				},
 			},
 			want: want{
@@ -145,7 +144,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 				},
 			},
 		},
@@ -210,7 +209,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 				},
 			},
 		},
@@ -282,7 +281,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 				},
 			},
 		},
@@ -380,7 +379,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 				},
 			},
 		},
@@ -436,7 +435,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 				},
 			},
 		},
@@ -537,7 +536,7 @@ func TestRunFunction(t *testing.T) {
 							// Note "new-resource" doesn't appear here.
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_WARNING,
@@ -652,7 +651,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 				},
 			},
 		},
@@ -715,7 +714,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 				},
 			},
 		},
@@ -785,7 +784,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 					},
-					Context: &structpb.Struct{Fields: map[string]*structpb.Value{fncontext.KeyEnvironment: structpb.NewStructValue(nil)}},
+					Context: contextWithEnvironment(nil),
 				},
 			},
 		},
@@ -1227,7 +1226,7 @@ func contextWithEnvironment(data map[string]interface{}) *structpb.Struct {
 		data = map[string]interface{}{}
 	}
 	u := unstructured.Unstructured{Object: data}
-	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "internal.crossplane.io", Version: "v1alpha1", Kind: "Environment"})
+	u.SetGroupVersionKind(internalEnvironmentGVK)
 	d, err := structpb.NewStruct(u.UnstructuredContent())
 	if err != nil {
 		panic(err)

--- a/patches.go
+++ b/patches.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/utils/ptr"
 
@@ -28,6 +29,10 @@ const (
 	errFmtCombineStrategyFailed       = "%s strategy could not combine"
 	errFmtExpandingArrayFieldPaths    = "cannot expand ToFieldPath %s"
 	errFmtInvalidPatchPolicy          = "invalid patch policy %s"
+)
+
+var (
+	internalEnvironmentGVK = schema.GroupVersionKind{Group: "internal.crossplane.io", Version: "v1alpha1", Kind: "Environment"}
 )
 
 // A PatchInterface is a patch that can be applied between resources.

--- a/validate.go
+++ b/validate.go
@@ -39,8 +39,8 @@ func ValidateResources(r *v1beta1.Resources) *field.Error {
 			return err
 		}
 	}
-	if len(r.Resources) == 0 {
-		return field.Required(field.NewPath("resources"), "resources is required")
+	if len(r.Resources) == 0 && (r.Environment == nil || len(r.Environment.Patches) == 0) {
+		return field.Required(field.NewPath("resources"), "resources or environment patches are required")
 	}
 	for i, r := range r.Resources {
 		if err := ValidateComposedTemplate(r); err != nil {


### PR DESCRIPTION
From https://crossplane.slack.com/archives/CEG3T90A1/p1716529989392019:
<details><summary>Details</summary>
<p>

Hello, hopefully someone here can point me in the right direction.
I'm struggling a bit to understan pipeline context. My current assumption is that I should be able to run a function-patch-and-transform  with a ToEnvironmentFieldPath  patch to write a value to the context.
This is my setup:
$ crossplane version
Client Version: v1.16.0
Server Version: v1.15.2-up.1
[XR from function-patch-and-transform multistep example](https://github.com/crossplane-contrib/function-patch-and-transform/blob/main/example/multistep/xr.yaml)
[functions from function-patch-and-transform multistep example](https://github.com/crossplane-contrib/function-patch-and-transform/blob/main/example/multistep/functions.yaml)
[composition from function-patch-and-transform multistep example](https://github.com/crossplane-contrib/function-patch-and-transform/blob/main/example/multistep/composition.yaml) with the addition below:
...

    - step: patch-and-transform-to-env
      functionRef:
        name: function-patch-and-transform
      input:
        apiVersion: pt.fn.crossplane.io/v1beta1
        kind: Resources
        resources:
          - name: bucketACL 
            patches:
              - type: ToEnvironmentFieldPath
                fromFieldPath: "spec.acl"
                toFieldPath: key1
$ crossplane beta render xr.yaml composition.yaml function.yaml --include-context

...
  54   │ ---
  55   │ apiVersion: render.crossplane.io/v1beta1
  56   │ fields:
  57   │   [apiextensions.crossplane.io/environment](http://apiextensions.crossplane.io/environment): {}
  58   │ kind: Context
I'm expecting to see a key1 in apiextensions.crossplane.io/environment, but maybe this is not how it works?

</p>
</details> 

The right approach was to instead define the following:
```yaml
    - step: patch-and-transform-to-env
      functionRef:
        name: function-patch-and-transform
      input:
        apiVersion: pt.fn.crossplane.io/v1beta1
        kind: Resources
        environment:
          patches:
            - type: FromCompositeFieldPath
              fromFieldPath: spec.acl
              toFieldPath: key1
```

But it didn't work firstly because not specifying `spec.resources` wasn't allowed, which shouldn't be the case.
But after faking a resource it was still failing because the environment was missing the gvk we expect and that crossplane would have set if it had passed an environment:
```
crossplane: error: cannot render composite resource: pipeline step "patch-and-transform-to-env" returned a fatal result: cannot apply the "FromCompositeFieldPath" environment patch at index 0: cannot patch to object: Object 'Kind' is missing in '{"key1":"private"}'
```

This PR fixes both issues.