### PR TITLE
fix: Add back support for To|FromEnvironmentFieldPath type in environment patches

### DIFF
--- a/input/v1beta1/resources_patches.go
+++ b/input/v1beta1/resources_patches.go
@@ -109,7 +109,7 @@ type EnvironmentPatch struct {
 	// Type sets the patching behaviour to be used. Each patch type may require
 	// its own fields to be set on the Patch object.
 	// +optional
-	// +kubebuilder:validation:Enum=FromCompositeFieldPath;ToCompositeFieldPath;CombineFromComposite;CombineToComposite
+	// +kubebuilder:validation:Enum=FromCompositeFieldPath;ToCompositeFieldPath;CombineFromComposite;CombineToComposite;FromEnvironmentFieldPath;ToEnvironmentFieldPath
 	// +kubebuilder:default=FromCompositeFieldPath
 	Type PatchType `json:"type,omitempty"`
 

--- a/package/input/pt.fn.crossplane.io_resources.yaml
+++ b/package/input/pt.fn.crossplane.io_resources.yaml
@@ -371,6 +371,8 @@ spec:
                       - ToCompositeFieldPath
                       - CombineFromComposite
                       - CombineToComposite
+                      - FromEnvironmentFieldPath
+                      - ToEnvironmentFieldPath
                       type: string
                   type: object
                 type: array

--- a/patches.go
+++ b/patches.go
@@ -198,21 +198,21 @@ func ApplyCombineFromVariablesPatch(p PatchInterface, from, to runtime.Object) e
 func ApplyEnvironmentPatch(p *v1beta1.EnvironmentPatch, env *unstructured.Unstructured, oxr, dxr *composite.Unstructured) error {
 	switch p.GetType() {
 	// From observed XR to environment.
-	case v1beta1.PatchTypeFromCompositeFieldPath:
+	case v1beta1.PatchTypeFromCompositeFieldPath,
+		v1beta1.PatchTypeToEnvironmentFieldPath:
 		return ApplyFromFieldPathPatch(p, oxr, env)
 	case v1beta1.PatchTypeCombineFromComposite:
 		return ApplyCombineFromVariablesPatch(p, oxr, env)
 
 	// From environment to desired XR.
-	case v1beta1.PatchTypeToCompositeFieldPath:
+	case v1beta1.PatchTypeToCompositeFieldPath,
+		v1beta1.PatchTypeFromEnvironmentFieldPath:
 		return ApplyFromFieldPathPatch(p, env, dxr)
 	case v1beta1.PatchTypeCombineToComposite:
 		return ApplyCombineFromVariablesPatch(p, env, dxr)
 
 	// Invalid patch types in this context.
-	case v1beta1.PatchTypeFromEnvironmentFieldPath,
-		v1beta1.PatchTypeCombineFromEnvironment,
-		v1beta1.PatchTypeToEnvironmentFieldPath,
+	case v1beta1.PatchTypeCombineFromEnvironment,
 		v1beta1.PatchTypeCombineToEnvironment:
 		// Nothing to do.
 

--- a/validate.go
+++ b/validate.go
@@ -103,7 +103,9 @@ func ValidateEnvironment(e *v1beta1.Environment) *field.Error {
 			v1beta1.PatchTypeFromCompositeFieldPath,
 			v1beta1.PatchTypeToCompositeFieldPath,
 			v1beta1.PatchTypeCombineFromComposite,
-			v1beta1.PatchTypeCombineToComposite:
+			v1beta1.PatchTypeCombineToComposite,
+			v1beta1.PatchTypeFromEnvironmentFieldPath,
+			v1beta1.PatchTypeToEnvironmentFieldPath:
 		default:
 			return field.Invalid(field.NewPath("patches").Index(i).Key("type"), p.GetType(), "invalid environment patch type")
 		}


### PR DESCRIPTION
Resolves #123
