### PR TITLE
add required to resources.patches.transforms.string.type

### DIFF
--- a/package/input/pt.fn.crossplane.io_resources.yaml
+++ b/package/input/pt.fn.crossplane.io_resources.yaml
@@ -348,6 +348,8 @@ spec:
                                 - Regexp
                                 type: string
                             type: object
+                            required:
+                              - type
                           type:
                             description: Type of the transform to be run.
                             enum:


### PR DESCRIPTION
Adding required to schema `resources.patches.transforms.string.type` . If not specified an error is returned i.e. `"patch-and-transform" returned a fatal result: invalid Function input: resources[1].patches[2].transforms[0].string.type: Required value: string transform type is required`
```
      resources:
        - base:
            apiVersion: aws.k8s.starter.org/v1alpha1
            kind: XEKS
          connectionDetails:
            - fromConnectionSecretKey: kubeconfig
              type: FromConnectionSecretKey
              name: kubeconfig
          name: compositeClusterEKS
          patches:
            - fromFieldPath: spec.id
              toFieldPath: spec.id
            - fromFieldPath: spec.id
              toFieldPath: metadata.annotations[crossplane.io/external-name]
            - fromFieldPath: metadata.uid
              toFieldPath: spec.writeConnectionSecretToRef.name
              transforms:
              - type: string
                string:
                  fmt: "%s-eks"
                  type: Format <-- this line
```