### PR TITLE
add required to resources.patches.transforms.string.type

### DIFF
--- a/input/v1beta1/resources_transforms.go
+++ b/input/v1beta1/resources_transforms.go
@@ -230,10 +230,9 @@ const (
 type StringTransform struct {
 
 	// Type of the string transform to be run.
-	// +optional
 	// +kubebuilder:validation:Enum=Format;Convert;TrimPrefix;TrimSuffix;Regexp
 	// +kubebuilder:default=Format
-	Type StringTransformType `json:"type,omitempty"`
+	Type StringTransformType `json:"type"`
 
 	// Format the input using a Go format string. See
 	// https://golang.org/pkg/fmt/ for details.

--- a/package/input/pt.fn.crossplane.io_resources.yaml
+++ b/package/input/pt.fn.crossplane.io_resources.yaml
@@ -347,6 +347,8 @@ spec:
                                 - TrimSuffix
                                 - Regexp
                                 type: string
+                            required:
+                            - type
                             type: object
                           type:
                             description: Type of the transform to be run.
@@ -705,6 +707,8 @@ spec:
                                   - TrimSuffix
                                   - Regexp
                                   type: string
+                              required:
+                              - type
                               type: object
                             type:
                               description: Type of the transform to be run.
@@ -1123,6 +1127,8 @@ spec:
                                   - TrimSuffix
                                   - Regexp
                                   type: string
+                              required:
+                              - type
                               type: object
                             type:
                               description: Type of the transform to be run.


### PR DESCRIPTION
Adding required to schema `resources.patches.transforms.string.type` . If not specified an error is returned i.e. `"patch-and-transform" returned a fatal result: invalid Function input: resources[1].patches[2].transforms[0].string.type: Required value: string transform type is required`
```
      resources:
        - base:
            apiVersion: aws.k8s.starter.org/v1alpha1
            kind: XEKS
          connectionDetails:
            - fromConnectionSecretKey: kubeconfig
              type: FromConnectionSecretKey
              name: kubeconfig
          name: compositeClusterEKS
          patches:
            - fromFieldPath: spec.id
              toFieldPath: spec.id
            - fromFieldPath: spec.id
              toFieldPath: metadata.annotations[crossplane.io/external-name]
            - fromFieldPath: metadata.uid
              toFieldPath: spec.writeConnectionSecretToRef.name
              transforms:
              - type: string
                string:
                  fmt: "%s-eks"
                  type: Format <-- this line
```