### PR TITLE
fix: Mark composite as unready if resources are skipped

### DIFF
--- a/fn_test.go
+++ b/fn_test.go
@@ -525,6 +525,7 @@ func TestRunFunction(t *testing.T) {
 					Desired: &fnv1beta1.State{
 						Composite: &fnv1beta1.Resource{
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","spec":{"widgets":"10"}}`),
+							Ready:    fnv1beta1.Ready_READY_FALSE,
 						},
 						Resources: map[string]*fnv1beta1.Resource{
 							// Note that the first patch did work. We only


### PR DESCRIPTION
This small fix marks the desired composite as unready in the response if one of the resource templates is skipped due to a missing required patch path.

Related to https://github.com/crossplane-contrib/function-patch-and-transform/issues/12.
Fixes https://github.com/crossplane-contrib/function-patch-and-transform/issues/152