### PR TITLE
chore: segregate internal logic to a package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+*.xpkg
 
 # Test binary, built with `go test -c`
 *.test

--- a/connection.go
+++ b/connection.go
@@ -10,6 +10,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane-contrib/function-patch-and-transform/input/v1beta1"
+	"github.com/crossplane-contrib/function-patch-and-transform/pt"
 )
 
 // ConnectionDetailsExtractor extracts the connection details of a resource.
@@ -33,7 +34,7 @@ func (fn ConnectionDetailsExtractorFn) ExtractConnection(cd resource.Composed, c
 func ExtractConnectionDetails(cd resource.Composed, data managed.ConnectionDetails, cfgs ...v1beta1.ConnectionDetail) (managed.ConnectionDetails, error) {
 	out := map[string][]byte{}
 	for _, cfg := range cfgs {
-		if err := ValidateConnectionDetail(cfg); err != nil {
+		if err := pt.ValidateConnectionDetail(cfg); err != nil {
 			return nil, errors.Wrap(err, "invalid")
 		}
 		switch cfg.Type {

--- a/pt/patches.go
+++ b/pt/patches.go
@@ -1,4 +1,4 @@
-package main
+package pt
 
 import (
 	"fmt"
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/utils/ptr"
 
@@ -29,10 +28,6 @@ const (
 	errFmtCombineStrategyFailed       = "%s strategy could not combine"
 	errFmtExpandingArrayFieldPaths    = "cannot expand ToFieldPath %s"
 	errFmtInvalidPatchPolicy          = "invalid patch policy %s"
-)
-
-var (
-	internalEnvironmentGVK = schema.GroupVersionKind{Group: "internal.crossplane.io", Version: "v1alpha1", Kind: "Environment"}
 )
 
 // A PatchInterface is a patch that can be applied between resources.

--- a/pt/patches_test.go
+++ b/pt/patches_test.go
@@ -1,4 +1,4 @@
-package main
+package pt
 
 import (
 	"testing"

--- a/pt/transforms.go
+++ b/pt/transforms.go
@@ -1,4 +1,4 @@
-package main
+package pt
 
 import (
 	"crypto/sha1" //nolint:gosec // Not used for secure hashing

--- a/pt/transforms_test.go
+++ b/pt/transforms_test.go
@@ -1,4 +1,4 @@
-package main
+package pt
 
 import (
 	"encoding/json"

--- a/pt/validate.go
+++ b/pt/validate.go
@@ -1,4 +1,4 @@
-package main
+package pt
 
 import (
 	"fmt"

--- a/pt/validate_test.go
+++ b/pt/validate_test.go
@@ -1,4 +1,4 @@
-package main
+package pt
 
 import (
 	"testing"

--- a/ready.go
+++ b/ready.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane-contrib/function-patch-and-transform/input/v1beta1"
+	"github.com/crossplane-contrib/function-patch-and-transform/pt"
 )
 
 // Error strings
@@ -59,7 +60,7 @@ func IsReady(_ context.Context, o ConditionedObject, rc ...v1beta1.ReadinessChec
 
 // RunReadinessCheck runs the readiness check against the supplied object.
 func RunReadinessCheck(c v1beta1.ReadinessCheck, o ConditionedObject) (bool, error) { //nolint:gocyclo // just a switch
-	if err := ValidateReadinessCheck(c); err != nil {
+	if err := pt.ValidateReadinessCheck(c); err != nil {
 		return false, errors.Wrap(err, errInvalidCheck)
 	}
 


### PR DESCRIPTION
The purpose here is to allow importing most of P&T logic into other functions, suck as `function-environment-config` (see [discussion](https://github.com/crossplane-contrib/function-environment-configs/issues/48)).
Per-se this should be a no-op.