### PR TITLE
chore: update go to 1.22.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.21.3'
+  GO_VERSION: '1.22.9'
   GOLANGCI_VERSION: 'v1.54.2'
   DOCKER_BUILDX_VERSION: 'v0.11.2'
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/crossplane-contrib/function-patch-and-transform
 
-go 1.21
+go 1.22
 
-toolchain go1.22.6
+toolchain go1.22.9
 
 require (
 	github.com/alecthomas/kong v0.9.0


### PR DESCRIPTION
Update go to 1.22.9 to.

1.21.3 has numerous CVEs.