### PR TITLE
Add a new github workflow 'tag'

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,26 @@
+name: Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v0.1.0)'
+        required: true
+      message:
+        description: 'Tag message'
+        required: true
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Create Tag
+        uses: negz/create-tag@39bae1e0932567a58c20dea5a1a0d18358503320 # v1
+        with:
+          version: ${{ github.event.inputs.version }}
+          message: ${{ github.event.inputs.message }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,22 @@
+
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# This file controls automatic PR reviewer assignment. See the following docs:
+#
+# * https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# * https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team
+#
+# The goal of this file is for most PRs to automatically and fairly have one
+# maintainer set as PR reviewers. All maintainers have permission to approve 
+# and merge PRs. All PRs must be approved by at least one maintainer before being merged.
+# 
+# Where possible, prefer explicitly specifying a maintainer who is a subject
+# matter expert for a particular part of the codebase rather than using fallback
+# owners. Fallback owners are listed at the bottom of this file.
+#
+# See also OWNERS.md for governance details
+
+# Fallback owners
+*			@sergenyalcin @turkenf @negz

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# OWNERS
+
+This page lists all maintainers for **this** repository. Each repository in the
+[Crossplane Contrib organization](https://github.com/crossplane-contrib/) will list their
+repository maintainers in their own `OWNERS.md` file.
+
+## Maintainers
+* Nic Cope <negz@upbound.com> ([negz](https://github.com/negz))
+* Sergen Yalcin <sergen@upbound.com> ([sergenyalcin](https://github.com/sergenyalcin))
+* Fatih Turken <fatih@upbound.com> ([turkenf](https://github.com/turkenf))
+
+See [CODEOWNERS](./CODEOWNERS) for automatic PR assignment.


### PR DESCRIPTION
This PR adds a new GitHub workflow `tag.yml`, and `OWNERS.md`, `CODEOWNERS` files.