### PR TITLE
chore(deps): update go to 1.24.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.23.4'
+  GO_VERSION: '1.24.0'
   GOLANGCI_VERSION: 'v1.62.2'
   DOCKER_BUILDX_VERSION: 'v0.11.2'
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/crossplane-contrib/function-patch-and-transform
 
-go 1.23
+go 1.24
 
-toolchain go1.23.4
+toolchain go1.24.0
 
 require (
 	github.com/alecthomas/kong v0.9.0


### PR DESCRIPTION
Updates go to 1.24.0 to address the vulnerabilities tied to 1.23.3

Context:

They are all found within /function when scanning the container

id | source | severity | package |
-- | ------ | -------- | ------- |
CVE-2025-22866 | Anchore CVE | Medium | stdlib-go1.23.4
CVE-2025-22866 | Twistlock CVE | Low | crypto/internal/nistec-1.23.4

Affected version: v0.8.1

Closes #161 