### PR TITLE
Add option for max grpc message size

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,10 +11,11 @@ import (
 type CLI struct {
 	Debug bool `short:"d" help:"Emit debug logs in addition to info logs."`
 
-	Network     string `help:"Network on which to listen for gRPC connections." default:"tcp"`
-	Address     string `help:"Address at which to listen for gRPC connections." default:":9443"`
-	TLSCertsDir string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
-	Insecure    bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	Network            string `help:"Network on which to listen for gRPC connections." default:"tcp"`
+	Address            string `help:"Address at which to listen for gRPC connections." default:":9443"`
+	TLSCertsDir        string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
+	Insecure           bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	MaxRecvMessageSize int    `help:"Maximum size of received messages in MB." default:"4"`
 }
 
 // Run this Function.
@@ -27,7 +28,8 @@ func (c *CLI) Run() error {
 	return function.Serve(&Function{log: log},
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
-		function.Insecure(c.Insecure))
+		function.Insecure(c.Insecure),
+		function.MaxRecvMessageSize(c.MaxRecvMessageSize*1024*1024))
 }
 
 func main() {


### PR DESCRIPTION
Adds a cli option, `--max-recv-message-size` to allow users to set the gRPC max message size. 

See for more information https://github.com/crossplane/crossplane/issues/6392