### PR TITLE
fix(security): remediate CVE vulnerabilities in Go 1.25.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25.8'
+  GO_VERSION: '1.25.9'
   GOLANGCI_VERSION: 'v2.4.0'
   DOCKER_BUILDX_VERSION: 'v0.23.0'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/function-patch-and-transform
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/alecthomas/kong v1.13.0


### PR DESCRIPTION
## Summary

This PR fixes CVE vulnerabilities identified by security scanning.

## Vulnerabilities Fixed

| CVE/GHSA | Severity | Package | Fixed Version |
|----------|----------|---------|---------------|
| CVE-2026-27140 | High | Go stdlib | 1.25.9 |
| CVE-2026-32283 | High | Go stdlib | 1.25.9 |
| CVE-2026-32280 | High | Go stdlib | 1.25.9 |
| CVE-2026-32281 | High | Go stdlib | 1.25.9 |
| CVE-2026-32289 | Medium | Go stdlib | 1.25.9 |
| CVE-2026-32282 | Medium | Go stdlib | 1.25.9 |
| CVE-2026-32288 | Medium | Go stdlib | 1.25.9 |

## Changes Made

- Updated Go version from 1.25.8 to 1.25.9 in \`go.mod\`
- Updated \`GO_VERSION\` to \`1.25.9\` in \`.github/workflows/ci.yml\`
- Ran \`go mod tidy\` to update dependencies

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-27140
- https://nvd.nist.gov/vuln/detail/CVE-2026-32283
- https://nvd.nist.gov/vuln/detail/CVE-2026-32280
- https://nvd.nist.gov/vuln/detail/CVE-2026-32281
- https://nvd.nist.gov/vuln/detail/CVE-2026-32289
- https://nvd.nist.gov/vuln/detail/CVE-2026-32282
- https://nvd.nist.gov/vuln/detail/CVE-2026-32288

## Verification

- [x] Rescanned with \`cve-scan\` skill after fixes
- [x] All listed vulnerabilities resolved