### PR TITLE
fix(security): remediate CVE vulnerabilities in release-0.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25.9'
+  GO_VERSION: '1.25.10'
   GOLANGCI_VERSION: 'v2.4.0'
   DOCKER_BUILDX_VERSION: 'v0.23.0'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/function-patch-and-transform
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/alecthomas/kong v1.13.0


### PR DESCRIPTION
## Summary

This PR fixes CVE vulnerabilities identified by security scanning.

## Vulnerabilities Fixed

| CVE/GHSA | Severity | Package | Fixed Version |
|----------|----------|---------|---------------|
| CVE-2026-39820 | High | stdlib (Go) | 1.25.10 |
| CVE-2026-42499 | High | stdlib (Go) | 1.25.10 |
| CVE-2026-39836 | High | stdlib (Go) | 1.25.10 |
| CVE-2026-33814 | High | stdlib (Go) | 1.25.10 |
| CVE-2026-33811 | High | stdlib (Go) | 1.25.10 |
| CVE-2026-42501 | High | stdlib (Go) | 1.25.10 |
| CVE-2026-39817 | Medium | stdlib (Go) | 1.25.10 |
| CVE-2026-39826 | Medium | stdlib (Go) | 1.25.10 |
| CVE-2026-39825 | Medium | stdlib (Go) | 1.25.10 |
| CVE-2026-39823 | Medium | stdlib (Go) | 1.25.10 |
| CVE-2026-39819 | Medium | stdlib (Go) | 1.25.10 |

## Changes Made

- Updated Go version from 1.25.9 to 1.25.10 in `go.mod`
- Updated `GO_VERSION` to 1.25.10 in `.github/workflows/ci.yml`
- Ran `go mod tidy` to update `go.sum`

## References

- [CVE-2026-39820](https://nvd.nist.gov/vuln/detail/CVE-2026-39820)
- [CVE-2026-42499](https://nvd.nist.gov/vuln/detail/CVE-2026-42499)
- [CVE-2026-39836](https://nvd.nist.gov/vuln/detail/CVE-2026-39836)
- [CVE-2026-33814](https://nvd.nist.gov/vuln/detail/CVE-2026-33814)
- [CVE-2026-33811](https://nvd.nist.gov/vuln/detail/CVE-2026-33811)
- [CVE-2026-42501](https://nvd.nist.gov/vuln/detail/CVE-2026-42501)
- [CVE-2026-39817](https://nvd.nist.gov/vuln/detail/CVE-2026-39817)
- [CVE-2026-39826](https://nvd.nist.gov/vuln/detail/CVE-2026-39826)
- [CVE-2026-39825](https://nvd.nist.gov/vuln/detail/CVE-2026-39825)
- [CVE-2026-39823](https://nvd.nist.gov/vuln/detail/CVE-2026-39823)
- [CVE-2026-39819](https://nvd.nist.gov/vuln/detail/CVE-2026-39819)

## Verification

- [x] Rescanned with `cve-scan` skill after fixes
- [x] All listed vulnerabilities resolved