### PR TITLE
Guard against negative capture group in regexp string transform

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -392,7 +392,7 @@ func stringRegexpTransform(input any, r v1beta1.StringTransformRegexp) (string, 
 
 	// Return the entire match (group zero) by default.
 	g := ptr.Deref[int](r.Group, 0)
-	if len(groups) == 0 || g >= len(groups) {
+	if len(groups) == 0 || g < 0 || g >= len(groups) {
 		return "", errors.Errorf(errStringTransformTypeRegexpNoMatch, r.Match, g)
 	}
 

--- a/transforms_test.go
+++ b/transforms_test.go
@@ -977,6 +977,19 @@ func TestStringResolve(t *testing.T) {
 				err: errors.Errorf(errStringTransformTypeRegexpNoMatch, "my-([0-9]+)-string", 2),
 			},
 		},
+		"RegexpNegativeCaptureGroup": {
+			args: args{
+				stype: v1beta1.StringTransformTypeRegexp,
+				regexp: &v1beta1.StringTransformRegexp{
+					Match: "my-([0-9]+)-string",
+					Group: ptr.To[int](-1),
+				},
+				i: "my-1-string",
+			},
+			want: want{
+				err: errors.Errorf(errStringTransformTypeRegexpNoMatch, "my-([0-9]+)-string", -1),
+			},
+		},
 		"ConvertToJSONSuccess": {
 			args: args{
 				stype:   v1beta1.StringTransformTypeConvert,


### PR DESCRIPTION
### What this does

`stringRegexpTransform` picks a capture group by index. The bounds check only covers the upper end:

```go
g := ptr.Deref[int](r.Group, 0)
if len(groups) == 0 || g >= len(groups) {
    return "", errors.Errorf(errStringTransformTypeRegexpNoMatch, r.Match, g)
}
return groups[g], nil
```

`Group` is a `*int`, so a Composition can set it to a negative value. A negative `g` passes both `len(groups) == 0` and `g >= len(groups)`, then `groups[g]` panics with an index out of range.

This adds the missing lower-bound check (`g < 0`) so a negative group returns the existing no-match error instead of panicking.

### Testing

Added a test case with `Group: -1`. Without the fix it panics:

```
panic: runtime error: index out of range [-1]
    ... stringRegexpTransform ... transforms.go:399
```

With the fix `go test ./...` passes and the negative group returns the no-match error like an out-of-range positive group already does.
