### PR TITLE
fix(security): remediate CVE vulnerabilities in Go stdlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   GOLANGCI_VERSION: 'v2.4.0'
   DOCKER_BUILDX_VERSION: 'v0.36.1'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/function-patch-and-transform
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/alecthomas/kong v1.16.0


### PR DESCRIPTION
## Summary

This PR fixes CVE vulnerabilities identified by security scanning.

## Vulnerabilities Fixed

| CVE/GHSA | Severity | Package | Fixed Version |
|----------|----------|---------|---------------|
| GO-2026-5026 | High | stdlib | go1.25.13 |
| GO-2026-5972 | High | stdlib | go1.25.13 |
| GO-2026-6088 | High | stdlib | go1.25.13 |
| GO-2026-6089 | High | stdlib | go1.25.13 |
| GO-2026-6090 | High | stdlib | go1.25.13 |
| GO-2026-6218 | Medium | stdlib | go1.25.13 |
| GO-2026-6091 | Medium | stdlib | go1.25.13 |

## Changes Made

- Updated Go version from 1.25.12 to 1.25.13 in `go.mod`
- Updated `GO_VERSION` from '1.25.12' to '1.25.13' in `.github/workflows/ci.yml`
- Ran `go mod tidy` to refresh dependencies

## References

- [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026)
- [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972)
- [GO-2026-6088](https://pkg.go.dev/vuln/GO-2026-6088)
- [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089)
- [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090)
- [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218)
- [GO-2026-6091](https://pkg.go.dev/vuln/GO-2026-6091)

## Verification

- [x] Rescanned with `cve-scan` skill after fixes
- [x] All listed vulnerabilities resolved